### PR TITLE
add --build option

### DIFF
--- a/_cmake
+++ b/_cmake
@@ -112,9 +112,23 @@ _cmake() {
       "$cmake_build_options[@]" && return 0
 }
 
-# -------------------
+# ------------------------
+# _cmake_generator_options
+# ------------------------
+(( $+functions[_cmake_generator_options] )) ||
+_cmake_generator_options() {
+  if [ -f $words[1]/Makefile ]
+  then
+    $_comps[make]
+  elif [ -f $words[1]/build.ninja ]
+  then
+    $_comps[ninja]
+  fi
+}
+
+# ------------
 # _cmake_build
-# -------------------
+# ------------
 (( $+functions[_cmake_build] )) ||
 _cmake_build() {
   _alternative ':current directory:(.)' 'directory::_directories'

--- a/_cmake
+++ b/_cmake
@@ -1,5 +1,30 @@
 #compdef cmake
-
+# ------------------------------------------------------------------------------
+# Copyright (c) 2011 Github zsh-users - http://github.com/zsh-users
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the zsh-users nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL ZSH-USERS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------------
 # Description
 # -----------
 #
@@ -163,7 +188,7 @@ _cmake_define_lang_property_names() {
     "CMAKE_${cmake_lang}_COMPILER:${cmake_lang_desc} compiler"
     "CMAKE_${cmake_lang}_FLAGS:${cmake_lang_desc} compiler flags for all builds"
     "CMAKE_${cmake_lang}_FLAGS_DEBUG:${cmake_lang_desc} compiler flags for all Debug build"
-    "CMAKE_${cmake_lang}_FLAGS_RLEASE:${cmake_lang_desc} compiler flags for all Relase build"
+    "CMAKE_${cmake_lang}_FLAGS_RELEASE:${cmake_lang_desc} compiler flags for all Relase build"
     "CMAKE_${cmake_lang}_FLAGS_MINSIZREL:${cmake_lang_desc} compiler flags for all MinSizRel build"
     "CMAKE_${cmake_lang}_FLAGS_RELWITHDEBINFO:${cmake_lang_desc} compiler flags for all RelWithDebInfo build"
   )
@@ -181,7 +206,7 @@ _cmake_define_common_property_names() {
     'CMAKE_TOOLCHAIN_FILE:Absolute or relative path to a cmake script which sets up toolchain related variables'
     'CMAKE_COLOR_MAKEFILE:Enables/disables color output when using the Makefile generator'
     'CMAKE_INSTALL_PREFIX:Install directory used by install'
-    'CMAKE_EXPORT_COMPILE_COMMANDS:Enable/disables output of compile commands during generation'
+    'CMAKE_EXPORT_COMPILE_COMMANDS:Enable/disable output of compilation database during generation'
   )
 
   _describe -t 'common-property-names' 'common property name' properties $@
@@ -195,14 +220,14 @@ _cmake_define_property_values() {
   local ret=1
   setopt localoptions extendedglob
   case $@[-1] in
-    (CMAKE_BUILD_TYPE)              _wanted build-types expl 'build type' _cmake_build_types && ret=0;;
-    (CMAKE_TOOLCHAIN_FILE)          _wanted toolchain-files expl 'file' _cmake_toolchain_files && ret=0;;
-    (CMAKE_COLOR_MAKEFILE)          _wanted booleans expl 'boolean' _cmake_booleans && ret=0;;
-    (CMAKE_INSTALL_PREFIX)          _files -/ && ret=0;;
+    (CMAKE_BUILD_TYPE)     _wanted build-types expl 'build type' _cmake_build_types && ret=0;;
+    (CMAKE_TOOLCHAIN_FILE) _wanted toolchain-files expl 'file' _cmake_toolchain_files && ret=0;;
+    (CMAKE_COLOR_MAKEFILE) _wanted booleans expl 'boolean' _cmake_booleans && ret=0;;
+    (CMAKE_INSTALL_PREFIX) _files -/ && ret=0;;
     (CMAKE_EXPORT_COMPILE_COMMANDS) _wanted booleans expl 'boolean' _cmake_booleans && ret=0;;
-    (CMAKE_*_COMPILER)              _wanted compilers expl 'compiler' _cmake_compilers && ret=0;;
-    (CMAKE_*_FLAGS(|_?*))           _message -e compiler-flags 'compiler flags' && ret=0;;
-    (*)                             _files && ret=0;;
+    (CMAKE_*_COMPILER)     _wanted compilers expl 'compiler' _cmake_compilers && ret=0;;
+    (CMAKE_*_FLAGS(|_?*))  _message -e compiler-flags 'compiler flags' && ret=0;;
+    (*)                    _files && ret=0;;
   esac
 
   return ret

--- a/_cmake
+++ b/_cmake
@@ -1,6 +1,6 @@
 #compdef cmake
 # ------------------------------------------------------------------------------
-# Copyright (c) 2011 Github zsh-users - http://github.com/zsh-users
+# Copyright (c) 2016 Github zsh-users - http://github.com/zsh-users
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -34,7 +34,8 @@
 # Authors
 # -------
 #
-#  * Scott M. Kroll <skroll@gmail.com>
+#  * Scott M. Kroll <skroll@gmail.com> (initial version)
+#  * Paul Seyfert <pseyfert@mathphys.fsk.uni-heidelberg.de> (handling of --build)
 #
 # -------------------------------------------------------------------------
 # Notes
@@ -49,32 +50,9 @@
 #
 # -------------------------------------------------------------------------
 
-_cmake() {
-  local context state line curcontext="$curcontext" cmake_args
+local context state line curcontext="$curcontext" cmake_args
 
-  local cmake_help_actions;cmake_help_actions=(
-    '(- 1)--help-command[Print help for a single command and exit]:command-name:_cmake_command_names'
-    '(- 1)--help-command-list[List available listfile commands and exit]'
-    '(- 1)--help-commands[Print help for all commands and exit]'
-    '(- 1)--help-compatcommands[Print help for compatibility commands]'
-    '(- 1)--help-module[Print help for compatibility commands]:module-name:_cmake_module_names'
-    '(- 1)--help-module-list[Print help for a single module and exit]'
-    '(- 1)--help-modules[Print help for all modules and exit]'
-    '(- 1)--help-property[List available properties and exit]:property-name:_cmake_property_names'
-    '(- 1)--help-property-list[List available properties and exit]'
-    '(- 1)--help-properties[Print help for all properties and exit]'
-    '(- 1)--help-variable[Print help for a single variable and exit]:variable-name:_cmake_variable_names'
-    '(- 1)--help-variable-list[List documented variables and exit]'
-    '(- 1)--help-variables[Print help for all variables and exit]'
-    '(- 1)--copyright[Print the CMake copyright and exit]'
-    '(- 1)'{--help,-help,-usage,-h,-H}'[Print usage information and exit]'
-    '(- 1)--help-full[Print full help and exit]'
-    '(- 1)--help-html[Print full help in HTML format]'
-    '(- 1)--help-man[Print full help as a UNIX man page and exit]'
-    '(- 1)'{--version,-version}'[Print full help as a UNIX man page and exit]'
-  )
-
-  local cmake_build_options;cmake_build_options=(
+local cmake_build_options;cmake_build_options=(
     '-C[Pre-load a script to populate the cache]:script:_files'
     '*-D-[Create a cmake cache entry]:property:_cmake_define_property'
     '-U[Remove matching entries from CMake cache]:globbing expression'
@@ -96,36 +74,17 @@ _cmake() {
     '--trace[Put cmake in trace mode]'
     '--find-package[Run in pkg-config like mode.]'
     ':cmake project:_files -/'
-  )
-
-  local cmake_build_commands;cmake_build_commands=(
-    '--build[Build a CMake-generated project binary tree]:_cmake_build:_cmake_build:_cmake_build_more:_cmake_build_more:_cmake_build_more'
-  )
-
-  local cmake_command_actions;cmake_command_actions=(
-    '-E[CMake command mode]:*:command'
-  )
-
-  _arguments -C -s \
-    - help \
-      "$cmake_help_actions[@]" \
-    - command \
-      "$cmake_command_actions[@]" \
-    - build_opts \
-      "$cmake_build_options[@]" \
-    - build_cmds \
-      "$cmake_build_commands[@]" && return 0
-}
+)
 
 # ------------------------
 # _cmake_generator_options
 # ------------------------
 (( $+functions[_cmake_generator_options] )) ||
 _cmake_generator_options() {
-  if [ -f $words[2]/Makefile ]
+  if [ -f $1/Makefile ]
   then
     $_comps[make]
-  elif [ -f $words[2]/build.ninja ]
+  elif [ -f $1/build.ninja ]
   then
     $_comps[ninja]
   fi
@@ -137,74 +96,103 @@ _cmake_generator_options() {
 (( $+functions[_cmake_targets] )) ||
 _cmake_targets() {
   local -a targets
-  if [ -f $words[2]/Makefile ]
+  if [ -f $1/Makefile ]
   then
     # make help doesn't work for Makefiles in general, but for cmake generated makefiles
-    targets=$(make help | sed "s/\.\.\. //")
-  elif [ -f $words[2]/build.ninja ]
+    i=1
+    for target in $(make help | \grep -e "\.\.\." | sed "s/\.\.\. //" | sed "s/ (the default.*//") ; do
+      targets[$i]=$target
+      (( i = $i + 1 ))
+    done
+  elif [ -f $1/build.ninja ]
   then
-    targets=$(ninja -C $words[2] -t targets all 2&>/dev/null | awk -F: '{print $1}')
+    i=1
+    for target in $(ninja -C $1 -t targets all 2&>/dev/null | awk -F: '{print $1}') ; do
+      targets[$i]="$target"
+      (( i++ ))
+    done
   fi
-  _describe -V 'build targets' targets
+  _describe 'build targets' targets
 }
 
-# -----------------
-# _cmake_build_more
-# -----------------
-(( $+functions[_cmake_build_more] )) ||
-_cmake_build_more() {
-  #local -a furz
-  #furz=('--config' '--target' '--clean-first')
-  #_describe 'foobarbaz' furz
-  echo "foobarbaz"
-  _arguments '--config' '--target' '--clean-first'
-
-##  while [[ $words[1] != "--build" ]];
-##  do
-##    shift words
-##    (( CURRENT-- ))
-##  done
-##
-##    local mybuffer;mybuffer=(
-##    '--config[For multi-configuration tools, choose <cfg>.]:config:_files'
-##    '--target[Build <tgt> instead of default targets.]:target:_cmake_targets'
-##    '--clean-first[Build target clean first, then build.]'
-##    #'--'
-##    )
-##
-##    _arguments -C -s \
-##      - stuff \
-##      "$mybuffer[@]"
-    ###_arguments "--target:target:_cmake_targets" "--config:config" "--clean-first[Build target 'clean' first]" "--:Native tool options:_cmake_generator_options"
-    ###local -a fooooo
-    ###fooooo=('--clean-first:Build target "clean" first' '--target[nondefaulttarget]')
-    ###_describe "somefoo" fooooo
-    ###_arguments '-l[list versions]' '-c[specify platform]:CMTCONFIG:__listcmt' '*: :__check_nightlies'
-    ##_arguments '*:build options:(--clean-first --use-stderr)'
-
-  # TODO: options after <dir> missing
-#       --build <dir>
-#              Build a CMake-generated project binary tree.
-#
-#              This abstracts a native build tool's command-line interface with the following options:
-#
-#                 <dir>          = Project binary directory to be built.
-#                 --target <tgt> = Build <tgt> instead of default targets.
-#                 --config <cfg> = For multi-configuration tools, choose <cfg>.
-#                 --clean-first  = Build target 'clean' first, then build.
-#                                  (To clean only, use --target 'clean'.)
-#                 --use-stderr   = Ignored.  Behavior is default in CMake >= 3.0.
-#                 --             = Pass remaining options to the native tool.
-#
-#              Run cmake --build with no options for quick help.
+_cmake_on_build() {
+  local build_extras;build_extras=(
+    '--[Native build tool options]'
+    '--target[specify build target]'
+    '--clean-first[build target clean first]'
+    '--config[For multi-configuration tools]'
+    '--use-stderr')
+  local -a undescribed_build_extras
+  i=1
+  for be in $build_extras ; do
+    undescribed_build_extras[$i]=$(echo $be | sed "s/\[.*//")
+    (( i++ ))
+  done
+  inbuild=false
+  nativemode=false
+  for ((i = (($CURRENT - 1)); i > 1 ; i--)); do
+    if [[ $words[$i] == --build ]] ; then
+      inbuild=true
+      buildat=$i
+      (( difference = $CURRENT - $i ))
+    elif [[ $words[$i] == -- ]] ; then
+      nativemode=true
+    fi
+  done
+  # check if build mode has been left
+  outofbuild=false
+  for ((i = (($CURRENT - 1)); i > (($buildat + 1)); i--)); do
+    # don't check the word after --build (should be a directory)
+    if [[ ${undescribed_build_extras[(r)$words[$i]]} == $words[$i] ]] ; then continue ; fi
+    if [[ $words[(($i - 1))] == --target ]] ; then continue ; fi
+    if [[ $words[(($i - 1))] == --config ]] ; then continue ; fi
+    outofbuild=true
+  done
+  if [ "$nativemode" = true ] ; then
+    _cmake_generator_options $words[(($buildat + 1))] && return 0
+  fi
+  if [ "$inbuild" = false ] ; then
+    _arguments -C -s \
+      - build_opts \
+      "$cmake_build_options[@]" \
+      - build_cmds \
+      "$cmake_suggest_build[@]" && return 0
+  elif [ $difference -eq 1 ] ; then
+    _alternative ':current directory:(.)' 'directory::_directories' && return 0
+  elif [[ $words[(($CURRENT - 1))] == --target ]] ; then
+    _cmake_targets $words[(($buildat + 1))] && return 0
+  elif [[ $words[(($CURRENT - 1))] == --config ]] ; then
+    return 0
+  elif [ "$outofbuild" = true ] ; then
+    _arguments "$cmake_build_options[@]" && return 0
+  else
+    _arguments "$build_extras[@]" "$cmake_build_options[@]" && return 0
+  fi
 }
 
-# ------------
-# _cmake_build
-# ------------
-(( $+functions[_cmake_build] )) ||
-_cmake_build() {
-  _alternative ':current directory:(.)' 'directory::_directories'
+local cmake_help_actions;cmake_help_actions=(
+    '(- 1)--help-command[Print help for a single command and exit]:command-name:_cmake_command_names'
+    '(- 1)--help-command-list[List available listfile commands and exit]'
+    '(- 1)--help-commands[Print help for all commands and exit]'
+    '(- 1)--help-compatcommands[Print help for compatibility commands]'
+    '(- 1)--help-module[Print help for compatibility commands]:module-name:_cmake_module_names'
+    '(- 1)--help-module-list[Print help for a single module and exit]'
+    '(- 1)--help-modules[Print help for all modules and exit]'
+    '(- 1)--help-property[List available properties and exit]:property-name:_cmake_property_names'
+    '(- 1)--help-property-list[List available properties and exit]'
+    '(- 1)--help-properties[Print help for all properties and exit]'
+    '(- 1)--help-variable[Print help for a single variable and exit]:variable-name:_cmake_variable_names'
+    '(- 1)--help-variable-list[List documented variables and exit]'
+    '(- 1)--help-variables[Print help for all variables and exit]'
+    '(- 1)--copyright[Print the CMake copyright and exit]'
+    '(- 1)'{--help,-help,-usage,-h,-H}'[Print usage information and exit]'
+    '(- 1)--help-full[Print full help and exit]'
+    '(- 1)--help-html[Print full help in HTML format]'
+    '(- 1)--help-man[Print full help as a UNIX man page and exit]'
+    '(- 1)'{--version,-version}'[Print full help as a UNIX man page and exit]'
+)
+_cmake_help() {
+  _arguments -C -s - help "$cmake_help_actions[@]"
 }
 
 # -------------------
@@ -402,6 +390,35 @@ _cmake_compilers() {
   _command_names -e
 }
 
+local cmake_command_actions;cmake_command_actions=(
+    '-E[CMake command mode]:*:command'
+)
+_cmake_command() {
+  _arguments -C -s - command "$cmake_command_actions[@]"
+}
 
-_cmake "$@"
+local cmake_suggest_build;cmake_suggest_build=(
+    '--build[build]'
+)
 
+#_alternative 'foobar::_cmake_on_build'
+if [ $CURRENT -eq 2 ] ; then
+  _arguments -C -s \
+    - help \
+      "$cmake_help_actions[@]" \
+    - command \
+      "$cmake_command_actions[@]" \
+    - build_opts \
+      "$cmake_build_options[@]" \
+    - build_cmds \
+      "$cmake_suggest_build[@]" && return 0
+  #  - build_cmds \
+  #    "$cmake_build_commands[@]"
+  #_alternative -C -s 'helps::_cmake_help' '::_cmake_on_build' 'command mode::_cmake_command' && return 0
+elif [[ $words[2] = --help* ]] ; then
+  _cmake_help
+elif [[ $words[2] != -E ]] ; then
+  _cmake_on_build
+else
+  _cmake_command
+fi

--- a/_cmake
+++ b/_cmake
@@ -95,8 +95,11 @@ _cmake() {
     '-L-[List cache variables]::_values "options" "[non-advanced cache variables]" "A[advanced cache variables]" "H[non-advanced cached variables with help]" "AH[advanced cache variables with help]"'
     '--trace[Put cmake in trace mode]'
     '--find-package[Run in pkg-config like mode.]'
-    '--build[Build a CMake-generated project binary tree]:build directory:_cmake_build'
     ':cmake project:_files -/'
+  )
+
+  local cmake_build_commands;cmake_build_commands=(
+    '--build[Build a CMake-generated project binary tree]:_cmake_build:_cmake_build:_cmake_build_more:_cmake_build_more:_cmake_build_more'
   )
 
   local cmake_command_actions;cmake_command_actions=(
@@ -109,7 +112,9 @@ _cmake() {
     - command \
       "$cmake_command_actions[@]" \
     - build_opts \
-      "$cmake_build_options[@]" && return 0
+      "$cmake_build_options[@]" \
+    - build_cmds \
+      "$cmake_build_commands[@]" && return 0
 }
 
 # ------------------------
@@ -117,23 +122,67 @@ _cmake() {
 # ------------------------
 (( $+functions[_cmake_generator_options] )) ||
 _cmake_generator_options() {
-  if [ -f $words[1]/Makefile ]
+  if [ -f $words[2]/Makefile ]
   then
     $_comps[make]
-  elif [ -f $words[1]/build.ninja ]
+  elif [ -f $words[2]/build.ninja ]
   then
     $_comps[ninja]
   fi
 }
 
-# ------------
-# _cmake_build
-# ------------
-(( $+functions[_cmake_build] )) ||
-_cmake_build() {
-  _alternative ':current directory:(.)' 'directory::_directories'
+# --------------
+# _cmake_targets
+# --------------
+(( $+functions[_cmake_targets] )) ||
+_cmake_targets() {
+  local -a targets
+  if [ -f $words[2]/Makefile ]
+  then
+    # make help doesn't work for Makefiles in general, but for cmake generated makefiles
+    targets=$(make help | sed "s/\.\.\. //")
+  elif [ -f $words[2]/build.ninja ]
+  then
+    targets=$(ninja -C $words[2] -t targets all 2&>/dev/null | awk -F: '{print $1}')
+  fi
+  _describe -V 'build targets' targets
+}
 
-# TODO: options after <dir> missing
+# -----------------
+# _cmake_build_more
+# -----------------
+(( $+functions[_cmake_build_more] )) ||
+_cmake_build_more() {
+  #local -a furz
+  #furz=('--config' '--target' '--clean-first')
+  #_describe 'foobarbaz' furz
+  echo "foobarbaz"
+  _arguments '--config' '--target' '--clean-first'
+
+##  while [[ $words[1] != "--build" ]];
+##  do
+##    shift words
+##    (( CURRENT-- ))
+##  done
+##
+##    local mybuffer;mybuffer=(
+##    '--config[For multi-configuration tools, choose <cfg>.]:config:_files'
+##    '--target[Build <tgt> instead of default targets.]:target:_cmake_targets'
+##    '--clean-first[Build target clean first, then build.]'
+##    #'--'
+##    )
+##
+##    _arguments -C -s \
+##      - stuff \
+##      "$mybuffer[@]"
+    ###_arguments "--target:target:_cmake_targets" "--config:config" "--clean-first[Build target 'clean' first]" "--:Native tool options:_cmake_generator_options"
+    ###local -a fooooo
+    ###fooooo=('--clean-first:Build target "clean" first' '--target[nondefaulttarget]')
+    ###_describe "somefoo" fooooo
+    ###_arguments '-l[list versions]' '-c[specify platform]:CMTCONFIG:__listcmt' '*: :__check_nightlies'
+    ##_arguments '*:build options:(--clean-first --use-stderr)'
+
+  # TODO: options after <dir> missing
 #       --build <dir>
 #              Build a CMake-generated project binary tree.
 #
@@ -148,6 +197,14 @@ _cmake_build() {
 #                 --             = Pass remaining options to the native tool.
 #
 #              Run cmake --build with no options for quick help.
+}
+
+# ------------
+# _cmake_build
+# ------------
+(( $+functions[_cmake_build] )) ||
+_cmake_build() {
+  _alternative ':current directory:(.)' 'directory::_directories'
 }
 
 # -------------------

--- a/_cmake
+++ b/_cmake
@@ -80,11 +80,22 @@ _cmake() {
     '-U[Remove matching entries from CMake cache]:globbing expression'
     '-G[Specify a makefile generator]:generator:_cmake_generators'
     '-T[Specify toolset name if supported by generator]:toolset name'
-    '(-Wno-dev -Wdev)-Wno-dev[Suppress developer warnings]'
-    '(-Wno-dev -Wdev)-Wdev[Enable developer warnings]'
+    '(-Wno-dev -Wdev)-Wno-dev[Suppress/Enable developer warnings]'
+    '(-Wno-dev -Wdev)-Wdev[Suppress/Enable developer warnings]'
+    '(-Wno-deprecated -Wdeprecated)-Wno-deprecated[Suppress/Enable deprecation warnings]'
+    '(-Wno-deprecated -Wdeprecated)-Wdeprecated[Suppress/Enable deprecation warnings]'
+    '(-Wno-error=dev -Werror=dev)-Wno-error=dev[Make developer warnings (not) errors]'
+    '(-Wno-error=dev -Werror=dev)-Werror=dev[Make developer warnings (not) errors]'
+    '(-Wno-error=deprecated -Werror=deprecated)-Werror=deprecated[Make deprecated macro and function warnings (not) errors]'
+    '(-Wno-error=deprecated -Werror=deprecated)-Wno-error=deprecated[Make deprecated macro and function warnings (not) errors]'
+    '--warn-uninitialized[Warn about uninitialized values.]'
+    '--warn-unused-vars[Warn about unused variables.]'
+    '--no-warn-unused-cli[Dont warn about command line options.]'
     '-i[Run in wizard mode]'
     '-L-[List cache variables]::_values "options" "[non-advanced cache variables]" "A[advanced cache variables]" "H[non-advanced cached variables with help]" "AH[advanced cache variables with help]"'
     '--trace[Put cmake in trace mode]'
+    '--find-package[Run in pkg-config like mode.]'
+    '--build[Build a CMake-generated project binary tree]:build directory:_cmake_build'
     ':cmake project:_files -/'
   )
 
@@ -99,6 +110,30 @@ _cmake() {
       "$cmake_command_actions[@]" \
     - build_opts \
       "$cmake_build_options[@]" && return 0
+}
+
+# -------------------
+# _cmake_build
+# -------------------
+(( $+functions[_cmake_build] )) ||
+_cmake_build() {
+  _alternative ':current directory:(.)' 'directory::_directories'
+
+# TODO: options after <dir> missing
+#       --build <dir>
+#              Build a CMake-generated project binary tree.
+#
+#              This abstracts a native build tool's command-line interface with the following options:
+#
+#                 <dir>          = Project binary directory to be built.
+#                 --target <tgt> = Build <tgt> instead of default targets.
+#                 --config <cfg> = For multi-configuration tools, choose <cfg>.
+#                 --clean-first  = Build target 'clean' first, then build.
+#                                  (To clean only, use --target 'clean'.)
+#                 --use-stderr   = Ignored.  Behavior is default in CMake >= 3.0.
+#                 --             = Pass remaining options to the native tool.
+#
+#              Run cmake --build with no options for quick help.
 }
 
 # -------------------


### PR DESCRIPTION
mostly ran RobSis/zsh-completion-generator and added `--build` to the expansion:
```
Usage: cmake --build <dir> [options] [-- [native-options]]
Options:
  <dir>          = Project binary directory to be built.
  --target <tgt> = Build <tgt> instead of default targets.
                   May only be specified once.
  --config <cfg> = For multi-configuration tools, choose <cfg>.
  --clean-first  = Build target 'clean' first, then build.
                   (To clean only, use --target 'clean'.)
  --use-stderr   = Ignored.  Behavior is default in CMake >= 3.0.
  --             = Pass remaining options to the native tool.

```
for gnu make and ninja, the targets are expanded and native options are obtained by forwarding to `$_comps[ninja]` or `$_comps[make]`.